### PR TITLE
Add `verbose` and `version` options

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -231,6 +231,7 @@ language_extensions:
 - DataKinds
 - FlexibleContexts
 - FlexibleInstances
+- LambdaCase
 - GeneralizedNewtypeDeriving
 - OverloadedLabels
 - OverloadedStrings
@@ -238,6 +239,7 @@ language_extensions:
 - QuasiQuotes
 - RankNTypes
 - StandaloneDeriving
+- TemplateHaskell
 - TypeFamilies
 - TypeOperators
 - TypeSynonymInstances

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       script: git clone -b gh-pages "https://${GH_TOKEN}@github.com/matsubara0507/whoami.git"
       after_success:
         - cd whoami
-        - stack exec -- whoami -o README.md -t markdown whoami.yaml
+        - stack exec -- whoami -v -o README.md -t markdown whoami.yaml
         - git config user.name "${GIT_NAME}"
         - git config user.email "${GIT_EMAIL}"
         - git status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+## 0.3.0.0
+
 - Feat: collect medium posts by user id
 - Refactor: remove dependent for shelly using threadDelay
 - Refactor: use throwM instead of throwIO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Feat: collect medium posts by user id
 - Refactor: remove dependent for shelly using threadDelay
 - Refactor: use throwM instead of throwIO
+- Feat: version and verbose options
+- Modify: default no log
 
 ## 0.2.0.0
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ cli usage
 whoami [options] [input-file]
   -o FILE               --output=FILE                Write output to FILE instead of stdout.
   -t FORMAT, -w FORMAT  --to=FORMAT, --write=FORMAT  Specify output format. default is `markdown`.
+  -v                    --verbose                    Enable verbose mode: verbosity level "debug"
+                        --version                    Show version
 ```
 
 e.g.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                whoami
-version:             0.2.0.0
+version:             0.3.0.0
 github:              "matsubara0507/whoami"
 license:             MIT
 author:              "MATSUBARA Nobutada"

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ default-extensions:
 - FlexibleContexts
 - FlexibleInstances
 - GeneralizedNewtypeDeriving
+- LambdaCase
 - NumericUnderscores
 - OverloadedLabels
 - OverloadedStrings
@@ -35,6 +36,7 @@ default-extensions:
 - QuasiQuotes
 - RankNTypes
 - StandaloneDeriving
+- TemplateHaskell
 - TypeFamilies
 - TypeOperators
 - TypeSynonymInstances
@@ -62,6 +64,7 @@ executables:
     source-dirs:         app
     dependencies:
     - whoami
+    - gitrev
 
 tests:
   whoami-test:

--- a/src/Whoami/Service/Data/Class.hs
+++ b/src/Whoami/Service/Data/Class.hs
@@ -45,10 +45,10 @@ instance Eq HttpException where
 
 instance Exception ServiceException
 
-runServiceM :: Config -> ServiceM a -> IO (Either ServiceException a)
-runServiceM config = try . Mix.run plugin
+runServiceM :: Bool -> Config -> ServiceM a -> IO (Either ServiceException a)
+runServiceM verb config = try . Mix.run plugin
   where
-    logConf = #handle @= stdout <: #verbose @= True <: nil
+    logConf = #handle @= stdout <: #verbose @= verb <: nil
     plugin = hsequence
         $ #config <@=> MixConfig.buildPlugin config
        <: #logger <@=> MixLogger.buildPlugin logConf

--- a/src/Whoami/Service/Data/Class.hs
+++ b/src/Whoami/Service/Data/Class.hs
@@ -37,6 +37,7 @@ data ServiceException
   | FillException Text
   | UniformException Text
   | ServiceException Text
+  | ReadConfigException Text
   deriving (Typeable, Show, Eq)
 
 instance Eq HttpException where

--- a/src/Whoami/Service/Internal/Fetch.hs
+++ b/src/Whoami/Service/Internal/Fetch.hs
@@ -44,7 +44,7 @@ get' url proxy =
         Nothing ->
           throwFetchError (Right $ "cannot parse url: " <> url)
   where
-    sleep' n = logInfo (display $ "fethed: " <> url) *> sleep n
+    sleep' n = logDebug (display $ "fethed: " <> url) *> sleep n
 
 
 runReq' :: (MonadIO m) => HttpConfig -> Req a -> m (Either HttpException a)

--- a/src/Whoami/Service/Internal/Fetch.hs
+++ b/src/Whoami/Service/Internal/Fetch.hs
@@ -44,7 +44,7 @@ get' url proxy =
         Nothing ->
           throwFetchError (Right $ "cannot parse url: " <> url)
   where
-    sleep' n = logDebug (display $ "fethed: " <> url) *> sleep n
+    sleep' n = logDebug (display $ "fetched: " <> url) *> sleep n
 
 
 runReq' :: (MonadIO m) => HttpConfig -> Req a -> m (Either HttpException a)

--- a/test/Test/Whoami/Output/Json.hs
+++ b/test/Test/Whoami/Output/Json.hs
@@ -68,5 +68,5 @@ test_toJsonText = do
   (Right conf) <- decodeFileEither exampleConfigFile
   sequence
     [ testCase "example to convert json" .
-        (@?= Right exampleJson) <$> runServiceM conf (toJsonText exampleInfos)
+        (@?= Right exampleJson) <$> runServiceM False conf (toJsonText exampleInfos)
     ]

--- a/test/Test/Whoami/Output/Markdown.hs
+++ b/test/Test/Whoami/Output/Markdown.hs
@@ -44,5 +44,5 @@ test_toMarkdown = do
   (Right conf) <- decodeFileEither exampleConfigFile
   sequence
     [ testCase "example to convert markdown" .
-        (@?= Right exampleMD) <$> runServiceM conf (toMarkdown exampleInfos)
+        (@?= Right exampleMD) <$> runServiceM False conf (toMarkdown exampleInfos)
     ]

--- a/test/Test/Whoami/Service/AnyApp.hs
+++ b/test/Test/Whoami/Service/AnyApp.hs
@@ -15,7 +15,7 @@ test_anyAppToInfo = do
   (Right conf) <- decodeFileEither exampleConfigFile
   sequence
     [ testCase "example app0 to uniformed info" .
-        (@?= Right app0) <$> runServiceM conf (toInfo . AnyApp $ (conf ^. #app) !! 0)
+        (@?= Right app0) <$> runServiceM False conf (toInfo . AnyApp $ (conf ^. #app) !! 0)
     , testCase "example app1 to uniformed info" .
-        (@?= Right app1) <$> runServiceM conf (toInfo . AnyApp $ (conf ^. #app) !! 1)
+        (@?= Right app1) <$> runServiceM False conf (toInfo . AnyApp $ (conf ^. #app) !! 1)
     ]

--- a/test/Test/Whoami/Service/AnyLib.hs
+++ b/test/Test/Whoami/Service/AnyLib.hs
@@ -15,7 +15,7 @@ test_anyLibToInfo = do
   (Right conf) <- decodeFileEither exampleConfigFile
   sequence
     [ testCase "example lib0 to uniformed info" .
-        (@?= Right lib0) <$> runServiceM conf (toInfo . AnyLib $ (conf ^. #library) !! 0)
+        (@?= Right lib0) <$> runServiceM False conf (toInfo . AnyLib $ (conf ^. #library) !! 0)
     , testCase "example lib1 to uniformed info" .
-        (@?= Right lib1) <$> runServiceM conf (toInfo . AnyLib $ (conf ^. #library) !! 1)
+        (@?= Right lib1) <$> runServiceM False conf (toInfo . AnyLib $ (conf ^. #library) !! 1)
     ]

--- a/test/Test/Whoami/Service/AnyPost.hs
+++ b/test/Test/Whoami/Service/AnyPost.hs
@@ -15,7 +15,7 @@ test_anyPostToInfo = do
   (Right conf) <- decodeFileEither exampleConfigFile
   sequence
     [ testCase "example post0 to uniformed info" .
-        (@?= Right post0) <$> runServiceM conf (toInfo . AnyPost $ (conf ^. #post ^. #posts) !! 0)
+        (@?= Right post0) <$> runServiceM False conf (toInfo . AnyPost $ (conf ^. #post ^. #posts) !! 0)
     , testCase "example post1 to uniformed info" .
-        (@?= Right post1) <$> runServiceM conf (toInfo . AnyPost $ (conf ^. #post ^. #posts) !! 1)
+        (@?= Right post1) <$> runServiceM False conf (toInfo . AnyPost $ (conf ^. #post ^. #posts) !! 1)
     ]

--- a/test/Test/Whoami/Service/AnySite.hs
+++ b/test/Test/Whoami/Service/AnySite.hs
@@ -15,5 +15,5 @@ test_anySiteToInfo = do
   (Right conf) <- decodeFileEither exampleConfigFile
   sequence
     [ testCase "example site0 to uniformed info" .
-        (@?= Right site0) <$> runServiceM conf (toInfo . AnySite $ (conf ^. #site) !! 0)
+        (@?= Right site0) <$> runServiceM False conf (toInfo . AnySite $ (conf ^. #site) !! 0)
     ]


### PR DESCRIPTION
`verbose` option is enable/disable rio logger.
`version` option is show cli version.

and more:
- default disable log message `fetched: ...`.
- bump version 0.3.0