### PR TITLE
Use base image on GitHub Container Registry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.3"]
+        ghc: ["8.10.4"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,9 @@ jobs:
     - name: Build and Test
       run: stack --system-ghc test --copy-bins --local-bin-path=./bin
 
+    - name: Run example
+      run: stack --system-ghc exec -- whoami -o example/whoami.md example/whoami.yaml
+
     # Build and Push Docker Image
     - name: Prepare
       id: prep

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
       with:
         registry: ghcr.io
         username: matsubara0507
-        password: ${{ secrets.CR_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
       uses: docker/build-push-action@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
         "
         restore-keys: |
           ${{ runner.os }}-stack-
-    - uses: haskell/actions/setup@v1.1.7
+    - uses: haskell/actions/setup@v1.2.1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -54,13 +54,13 @@ jobs:
         fi
         echo ::set-output name=tags::${TAGS}
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@master
+      uses: docker/setup-qemu-action@v1
       with:
         platforms: all
 
     - name: Setup Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@master
+      uses: docker/setup-buildx-action@v1
       with:
         version: latest
 

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.3"]
+        ghc: ["8.10.4"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -36,7 +36,7 @@ jobs:
         "
         restore-keys: |
           ${{ runner.os }}-stack-
-    - uses: haskell/actions/setup@v1.1.7
+    - uses: haskell/actions/setup@v1.2.1
       name: Setup Haskell
       with:
         ghc-version: ${{ matrix.ghc }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog for whoami
 
-## Unreleased changes
+## 1.1.0
 
 - Misc: update LTS to 17.0
 - CI: change to GitHub Actions from TravisCI
 - Image: use GitHub Container Registry instead of Docker Hub
+- Misc: update LTS to 17.15
+- Image: use base image on GHCR
 
 ## 1.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM matsubara0507/ubuntu-for-haskell
+FROM ghcr.io/matsubara0507/ubuntu-for-haskell
 ARG local_bin_path
 RUN mkdir -p /root/.local/bin && mkdir -p /work
 ENV PATH /root/.local/bin:$PATH

--- a/package.yaml
+++ b/package.yaml
@@ -1,9 +1,8 @@
 name: whoami
-version: 1.0.0
+version: 1.1.0
 github: "matsubara0507/whoami"
 license: MIT
 author: "MATSUBARA Nobutada"
-maintainer: "t12307043@gunma-u.ac.jp"
 copyright: "2018 MATSUBARA Nobutada"
 
 extra-source-files:

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,5 +11,5 @@ extra-deps:
   - mix
 
 docker:
-  repo: matsubara0507/stack-build
+  repo: ghcr.io/matsubara0507/stack-build:18.04
   enable: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,8 @@
-resolver: lts-17.0
+resolver: lts-17.15
 packages:
 - .
 extra-deps:
-- extensible-0.8.1
+- extensible-0.8.2
 - incremental-0.3.1
 - membership-0
 - github: matsubara0507/mix.hs

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: extensible-0.8.1@sha256:280840e31d92510b342d6a8d82d7af39cfd250194f9c26fca1d5cd406ee206f6,2946
+    hackage: extensible-0.8.2@sha256:f3e7497709199034222e10ba45d3730e21155fb89159ccf1fb0b55f1d7d02697,2963
     pantry-tree:
-      size: 2097
-      sha256: 49d78392bc6da683fe08b01b7e513b5eb471df1b8157616ca4d9dad0a9a23d3d
+      size: 2041
+      sha256: 29d9d1cfb1c5348141f859e74739d212d3c5af9ff0ec359e3f66f872d4be8bc6
   original:
-    hackage: extensible-0.8.1
+    hackage: extensible-0.8.2
 - completed:
     hackage: incremental-0.3.1@sha256:9c697bae4f7e5ceb144bde13e03ca2f36b4bc2d0c92bbc02e0a604231ee279c2,1153
     pantry-tree:
@@ -40,7 +40,7 @@ packages:
     url: https://github.com/matsubara0507/mix.hs/archive/75714be080db16f6a4f9d0a22e86947ffcdadc57.tar.gz
 snapshots:
 - completed:
-    size: 563100
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/0.yaml
-    sha256: e93a85871577ea3423d5f3454b2b6bd37c2c2123c79faf511dfb64f5b49a9f8b
-  original: lts-17.0
+    size: 567679
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/15.yaml
+    sha256: 72e87841a0ab5b72f6f018e8ee692fd972b7bb32a944990f028e10d6eb528e63
+  original: lts-17.15


### PR DESCRIPTION
and

- Refactor: update LTS to 17.15
- CI: update actions
- CI: add running example
- CI: use GITHUB_TOKEN instead of CR_PAT to push GitHub Container Registry